### PR TITLE
QUAD-50: Fixing the bug where dictionary items were not getting

### DIFF
--- a/Quadriga/src/main/java/edu/asu/spring/quadriga/service/dictionary/mapper/impl/DictionaryDeepMapper.java
+++ b/Quadriga/src/main/java/edu/asu/spring/quadriga/service/dictionary/mapper/impl/DictionaryDeepMapper.java
@@ -112,7 +112,7 @@ public class DictionaryDeepMapper implements IDictionaryDeepMapper {
 		IDictionary dictionary = null;
 		
 		DictionaryDTO dictionaryDTO = dictDao.getDTO(dictionaryId);
-		if (!dictionaryDTO.getOwner().equals(userName))
+		if (!dictionaryDTO.getOwner().getCreatedby().equals(userName))
 		    return null;
 		
 		dictionary = dictionaryFactory.createDictionaryObject();


### PR DESCRIPTION
Fixing the bug where dictionary items were not getting retrieved. Replaced dictionaryDTO.getOwner() with dictionaryDTO.getOwner().getCreatedby()
