### PR TITLE
QUAD-115: transfered 'edit about' to private auth/ directory

### DIFF
--- a/Quadriga/src/main/java/edu/asu/spring/quadriga/web/publicwebsite/WebsiteAboutEditController.java
+++ b/Quadriga/src/main/java/edu/asu/spring/quadriga/web/publicwebsite/WebsiteAboutEditController.java
@@ -26,7 +26,7 @@ public class WebsiteAboutEditController {
     @Autowired
     private IRetrieveProjectManager projectManager;
 
-    @RequestMapping(value = "sites/{ProjectUnixName}/EditAbout", method = RequestMethod.GET)
+    @RequestMapping(value = "auth/editabout/{ProjectUnixName}", method = RequestMethod.GET)
     public String showAbout(@PathVariable("ProjectUnixName") String unixName, Model model, Principal principal) throws QuadrigaStorageException {
         IProject project = projectManager.getProjectDetailsByUnixName(unixName);
         String title = "Project Title will be here";
@@ -34,7 +34,7 @@ public class WebsiteAboutEditController {
         model.addAttribute("project", project);
         model.addAttribute("title", title);
         model.addAttribute("aboutProject", aboutProject);
-        return "sites/settings/publicWebsiteEditAbout";
+        return "auth/editabout";
     }
 
 }

--- a/Quadriga/src/main/webapp/WEB-INF/spring/spring-security.xml
+++ b/Quadriga/src/main/webapp/WEB-INF/spring/spring-security.xml
@@ -36,6 +36,7 @@
 		<intercept-url pattern="/auth/users/**" access="hasRole('ROLE_QUADRIGA_USER_ADMIN')"/>
 		<intercept-url pattern="/requests/*" access="hasRole('ROLE_QUADRIGA_NOACCOUNT')"/>
 		<intercept-url pattern="/auth/profile/**" access="hasAnyRole('ROLE_QUADRIGA_USER_ADMIN','ROLE_QUADRIGA_USER_STANDARD','ROLE_QUADRIGA_USER_COLLABORATOR')"/>
+		<intercept-url pattern="/auth/editAbout/**" access="hasAnyRole('ROLE_QUADRIGA_USER_ADMIN','ROLE_QUADRIGA_USER_STANDARD','ROLE_QUADRIGA_USER_COLLABORATOR')"/>
 		<intercept-url pattern="/sites/**" access="permitAll" />
 		<intercept-url pattern="/**" access="denyAll" />
 		

--- a/Quadriga/src/main/webapp/WEB-INF/tiles-defs.xml
+++ b/Quadriga/src/main/webapp/WEB-INF/tiles-defs.xml
@@ -704,8 +704,8 @@
 		<put-attribute name="content" value="/WEB-INF/views/public/publicwebsiteabout.jsp"/>
 	</definition>
 	
-	<definition name="sites/settings/publicWebsiteEditAbout" extends="base.definition.public">
-	   <put-attribute name="currentPage" value="EditAbout" />
+	<definition name="auth/editabout" extends="base.definition">
+	   <put-attribute name="currentPage" value="editabout" />
 		<put-attribute name="content" value="/WEB-INF/views/settings/publicWebsiteEditAbout.jsp"/>
 	</definition>
 	


### PR DESCRIPTION
There was a comment in push request from QUAD-115 to develop (Story/quad 115 #152)
"Same as for the JSP, the page should not be accessible through the "sites" url and by anyone. It should be under "auth/..." and only project admins and owners should be able to access it."

This has been addressed in this branch.
